### PR TITLE
Update sobject-pojo-optional.vm

### DIFF
--- a/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/resources/sobject-pojo-optional.vm
+++ b/components/camel-salesforce/camel-salesforce-maven-plugin/src/main/resources/sobject-pojo-optional.vm
@@ -61,7 +61,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 public class ${desc.Name}Optional extends AbstractSObjectBase {
 
 #foreach ( $field in $desc.Fields )
-#set ( ($fieldType = $utility.getFieldType($desc, $field)) && ($fieldType) )
+#set ( $fieldType = $utility.getFieldType($desc, $field) )
 #if ( $utility.notBaseField($field.Name) )
 #set ( $fieldName = $field.Name )
 #set ( $isMultiSelectPicklist = $utility.isMultiSelectPicklist($field) )


### PR DESCRIPTION
Fixed error in setting the $fieldType - the syntax in the template document throws the  following error upon running:

[ERROR] Failed to execute goal org.apache.camel.maven:camel-salesforce-maven-plugin:2.21.0:generate (executable pom) on project test-project: Execution executable pom of goal org.apache.camel.maven:camel-salesforce-maven-plugin:2.21.0:generate failed: Encountered "(" at /sobject-pojo-optional.vm[line 64, column 8]
[ERROR] Was expecting one of:
[ERROR]     <WHITESPACE> ...
[ERROR]     <NEWLINE> ...
[ERROR]     <IDENTIFIER> ...
[ERROR]     "{" ...


This change fixes that.